### PR TITLE
Added linux build option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,3 @@
 npx electron-builder --mac --universal
 npx electron-builder --win --x64
+npx electron-builder --linux --x64

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affinity-script-manager",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affinity-script-manager",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "latest"
       },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     "win": {
       "target": "nsis",
       "icon": "assets/icon.png"
+    },
+    "linux": {
+      "target": "AppImage",
+      "icon": "assets/icon.png"
     }
   }
 }


### PR DESCRIPTION
Since the MCP server works also on the [Affinity on Linux](https://github.com/ryzendew/Linux-Affinity-Installer) version, it is better to have a native Linux build in that case. Tested and works correctly.